### PR TITLE
Convert fluent getters to Kotlin getters (Fix #15)

### DIFF
--- a/shardManager/src/main/kotlin/space/votebot/shardmanager/Application.kt
+++ b/shardManager/src/main/kotlin/space/votebot/shardmanager/Application.kt
@@ -25,7 +25,7 @@ import space.votebot.shardmanager.config.Config
 
 fun main() {
     val config = Config()
-    Sentry.init(config.sentryDsn())
-    val serviceRegistry = ConsulRegistry(ShardManagerAPI.SERVICE_ID, config.consulHost(), config.consulPort())
+    Sentry.init(config.sentryDsn)
+    val serviceRegistry = ConsulRegistry(ShardManagerAPI.SERVICE_ID, config.consulHost, config.consulPort)
     serviceRegistry.register(5050)
 }

--- a/shardManager/src/main/kotlin/space/votebot/shardmanager/config/Config.kt
+++ b/shardManager/src/main/kotlin/space/votebot/shardmanager/config/Config.kt
@@ -26,9 +26,21 @@ class Config {
         ignoreIfMissing = true
     }
 
-    fun consulHost() = dotenv["${PREFIX}CONSUL_HOST"] ?: "localhost"
-    fun consulPort() = Integer.parseInt(dotenv["${PREFIX}CONSUL_PORT"] ?: "8500")
-    fun sentryDsn() = dotenv["${PREFIX}SENTRY_DSN"]!!
+    val consulHost
+        get() = dotenv["${PREFIX}CONSUL_HOST"] ?: "localhost"
+
+    val consulPort
+        get() = dotenv["${PREFIX}CONSUL_PORT"]?.toInt() ?:8500
+
+    val sentryDsn
+        get() = dotenv["${PREFIX}SENTRY_DSN"]!!
+
+    @Deprecated("Fluent getters got replaced by Kotlin getters", ReplaceWith("consulHost"))
+    fun consulHost() = consulHost
+    @Deprecated("Fluent getters got replaced by Kotlin getters", ReplaceWith("consulPort"))
+    fun consulPort() = consulPort
+    @Deprecated("Fluent getters got replaced by Kotlin getters", ReplaceWith("sentryDsn"))
+    fun sentryDsn() = sentryDsn
 
     companion object {
         const val PREFIX = "SHARDMANAGER_"

--- a/shardManager/src/main/kotlin/space/votebot/shardmanager/config/Config.kt
+++ b/shardManager/src/main/kotlin/space/votebot/shardmanager/config/Config.kt
@@ -35,13 +35,6 @@ class Config {
     val sentryDsn
         get() = dotenv["${PREFIX}SENTRY_DSN"]!!
 
-    @Deprecated("Fluent getters got replaced by Kotlin getters", ReplaceWith("consulHost"))
-    fun consulHost() = consulHost
-    @Deprecated("Fluent getters got replaced by Kotlin getters", ReplaceWith("consulPort"))
-    fun consulPort() = consulPort
-    @Deprecated("Fluent getters got replaced by Kotlin getters", ReplaceWith("sentryDsn"))
-    fun sentryDsn() = sentryDsn
-
     companion object {
         const val PREFIX = "SHARDMANAGER_"
     }


### PR DESCRIPTION
- Deprecate fluent getters
- Migrate to Kotlin getters
- Upgrade deprecated calls